### PR TITLE
Fixed invalid mapping for HuobiOrder

### DIFF
--- a/Huobi.Net.UnitTests/HuobiClientTests.cs
+++ b/Huobi.Net.UnitTests/HuobiClientTests.cs
@@ -55,8 +55,8 @@ namespace Huobi.Net.UnitTests
                 High = 0.5m,
                 Volume = 0.6m,
                 TradeCount = 123,
-                BestAsk = new HuobiOrderBookEntry(){ Amount = 0.7m, Price = 0.8m},
-                BestBid = new HuobiOrderBookEntry(){ Amount = 0.9m, Price = 1.0m },
+                BestAsk = new HuobiOrderBookEntry() { Amount = 0.7m, Price = 0.8m },
+                BestBid = new HuobiOrderBookEntry() { Amount = 0.9m, Price = 1.0m },
                 Version = 1
             };
 
@@ -103,7 +103,7 @@ namespace Huobi.Net.UnitTests
         {
             // arrange
             var expected = new HuobiMarketDepth()
-            { 
+            {
                 Asks = new List<HuobiOrderBookEntry>()
                 {
                     new HuobiOrderBookEntry(){ Amount = 0.1m, Price = 0.2m}
@@ -334,9 +334,9 @@ namespace Huobi.Net.UnitTests
         public void GetOpenOrders_Should_RespondWithOpenOrders()
         {
             // arrange
-            var expected = new List<HuobiOrder>()
+            var expected = new List<HuobiOpenOrder>()
             {
-                new HuobiOrder()
+                new HuobiOpenOrder()
                 {
                     Amount = 0.1m,
                     Type = HuobiOrderType.LimitBuy,
@@ -346,7 +346,11 @@ namespace Huobi.Net.UnitTests
                     State = HuobiOrderState.Submitted,
                     AccountId = 1234,
                     CreatedAt = new DateTime(2018, 1, 1),
-                    Source = "API"
+                    FinishedAt = new DateTime(2019, 1, 1),
+                    Source = "API",
+                    FilledAmount = 1.1m,
+                    FilledFees = 1.2m,
+                    FilledCashAmount = 1.3m
                 }
             };
 
@@ -380,8 +384,8 @@ namespace Huobi.Net.UnitTests
             // arrange
             var expected = new HuobiBatchCancelResult()
             {
-                Successful = new long[] {123},
-                Failed = new []
+                Successful = new long[] { 123 },
+                Failed = new[]
                 {
                     new HuobiFailedCancelResult()
                     {
@@ -395,7 +399,7 @@ namespace Huobi.Net.UnitTests
             var client = TestHelpers.CreateAuthResponseClient(SerializeExpected(expected, true));
 
             // act
-            var result = client.CancelOrders(new long[] {123, 1234});
+            var result = client.CancelOrders(new long[] { 123, 1234 });
 
             // assert
             Assert.AreEqual(true, result.Success);
@@ -417,7 +421,10 @@ namespace Huobi.Net.UnitTests
                 State = HuobiOrderState.Submitted,
                 AccountId = 1234,
                 CreatedAt = new DateTime(2018, 1, 1),
-                Source = "API"
+                Source = "API",
+                FilledAmount = 1.1m,
+                FilledCashAmount = 1.2m,
+                FilledFees = 1.3m
             };
 
             var client = TestHelpers.CreateAuthResponseClient(SerializeExpected(expected, true));
@@ -477,14 +484,17 @@ namespace Huobi.Net.UnitTests
                     State = HuobiOrderState.Submitted,
                     AccountId = 1234,
                     CreatedAt = new DateTime(2018, 1, 1),
-                    Source = "API"
+                    Source = "API",
+                    FilledAmount = 1.1m,
+                    FilledCashAmount = 1.2m,
+                    FilledFees = 1.3m
                 }
             };
 
             var client = TestHelpers.CreateAuthResponseClient(SerializeExpected(expected, true));
 
             // act
-            var result = client.GetOrders("BTCETH", new [] { HuobiOrderState.Submitted });
+            var result = client.GetOrders("BTCETH", new[] { HuobiOrderState.Submitted });
 
             // assert
             Assert.AreEqual(true, result.Success);
@@ -556,7 +566,7 @@ namespace Huobi.Net.UnitTests
 
         public string SerializeExpected<T>(T data, bool tick)
         {
-            return $"{{\"status\": \"ok\", {(tick ? "tick": "data")}: {JsonConvert.SerializeObject(data)}}}";
+            return $"{{\"status\": \"ok\", {(tick ? "tick" : "data")}: {JsonConvert.SerializeObject(data)}}}";
         }
     }
 }

--- a/Huobi.Net/HuobiClient.cs
+++ b/Huobi.Net/HuobiClient.cs
@@ -397,7 +397,7 @@ namespace Huobi.Net
         /// <param name="side">Only get buy or sell orders</param>
         /// <param name="limit">The max number of results</param>
         /// <returns></returns>
-        public CallResult<List<HuobiOrder>> GetOpenOrders(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null) => GetOpenOrdersAsync(accountId, symbol, side, limit).Result;
+        public CallResult<List<HuobiOpenOrder>> GetOpenOrders(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null) => GetOpenOrdersAsync(accountId, symbol, side, limit).Result;
         /// <summary>
         /// Gets a list of open orders
         /// </summary>
@@ -406,10 +406,10 @@ namespace Huobi.Net
         /// <param name="side">Only get buy or sell orders</param>
         /// <param name="limit">The max number of results</param>
         /// <returns></returns>
-        public async Task<CallResult<List<HuobiOrder>>> GetOpenOrdersAsync(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null)
+        public async Task<CallResult<List<HuobiOpenOrder>>> GetOpenOrdersAsync(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null)
         {
             if (accountId != null && symbol == null)
-                return new CallResult<List<HuobiOrder>>(null, new ArgumentError("Can't request open orders based on only the account id"));
+                return new CallResult<List<HuobiOpenOrder>>(null, new ArgumentError("Can't request open orders based on only the account id"));
 
             var parameters = new Dictionary<string, object>();
             parameters.AddOptionalParameter("account-id", accountId);
@@ -417,8 +417,8 @@ namespace Huobi.Net
             parameters.AddOptionalParameter("side", side == null ? null: JsonConvert.SerializeObject(side, new OrderSideConverter(false)));
             parameters.AddOptionalParameter("size", limit);
 
-            var result = await ExecuteRequest<HuobiBasicResponse<List<HuobiOrder>>>(GetUrl(OpenOrdersEndpoint, "1"), "GET", parameters, true).ConfigureAwait(false);
-            return new CallResult<List<HuobiOrder>>(result.Data?.Data, result.Error);
+            var result = await ExecuteRequest<HuobiBasicResponse<List<HuobiOpenOrder>>>(GetUrl(OpenOrdersEndpoint, "1"), "GET", parameters, true).ConfigureAwait(false);
+            return new CallResult<List<HuobiOpenOrder>>(result.Data?.Data, result.Error);
         }
 
         /// <summary>

--- a/Huobi.Net/Interfaces/IHuobiClient.cs
+++ b/Huobi.Net/Interfaces/IHuobiClient.cs
@@ -213,7 +213,7 @@ namespace Huobi.Net.Interfaces
         /// <param name="side">Only get buy or sell orders</param>
         /// <param name="limit">The max number of results</param>
         /// <returns></returns>
-        CallResult<List<HuobiOrder>> GetOpenOrders(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null);
+        CallResult<List<HuobiOpenOrder>> GetOpenOrders(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null);
 
         /// <summary>
         /// Gets a list of open orders
@@ -223,7 +223,7 @@ namespace Huobi.Net.Interfaces
         /// <param name="side">Only get buy or sell orders</param>
         /// <param name="limit">The max number of results</param>
         /// <returns></returns>
-        Task<CallResult<List<HuobiOrder>>> GetOpenOrdersAsync(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null);
+        Task<CallResult<List<HuobiOpenOrder>>> GetOpenOrdersAsync(long? accountId = null, string symbol = null, HuobiOrderSide? side = null, int? limit = null);
 
         /// <summary>
         /// Cancels an open order

--- a/Huobi.Net/Objects/HuobiOpenOrder.cs
+++ b/Huobi.Net/Objects/HuobiOpenOrder.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Huobi.Net.Objects
 {
-    public class HuobiOrder
+    public class HuobiOpenOrder
     {
         /// <summary>
         /// The id of the order
@@ -72,16 +72,16 @@ namespace Huobi.Net.Objects
         /// <summary>
         /// The amount of the order that is filled
         /// </summary>
-        [JsonProperty("field-amount")]
+        [JsonProperty("filled-amount")]
         public decimal FilledAmount { get; set; }
 
-        [JsonProperty("field-cash-amount")]
+        [JsonProperty("filled-cash-amount")]
         public decimal FilledCashAmount { get; set; }
 
         /// <summary>
         /// The amount of fees paid for the filled amount
         /// </summary>
-        [JsonProperty("field-fees")]
+        [JsonProperty("filled-fees")]
         public decimal FilledFees { get; set; }
     }
 }


### PR DESCRIPTION
Real world response 
`{
    \
    "status\":\"ok\",\"data\":{\"id\":22899445812,\"symbol\":\"htbtc\",\"account-id\":5123800,\"amount\":\"0.000116680000000000\",\"price\":\"0.0\",\"created-at\":1548344698836,\"type\":\"buy-market\",
    \"field-amount\":\"0.399986307503718286\",\"field-cash-amount\":\"0.000116679999999999\",\"field-fees\":\"0.000799972615007437\",
    \"finished-at\":1548344698950,\"source\":\"spot-api\",\"state\":\"filled\",\"canceled-at\":0}
}`

In documentation Huobi also uses `field-amount`, `field-cash-amount`, `field-fees` instead of `filled` 
