### PR TITLE
Stop-limit orders parsing fix

### DIFF
--- a/Huobi.Net/Converters/OrderStateConverter.cs
+++ b/Huobi.Net/Converters/OrderStateConverter.cs
@@ -16,7 +16,8 @@ namespace Huobi.Net.Converters
             new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.PartiallyFilled, "partial-filled"),
             new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.PartiallyCanceled, "partial-canceled"),
             new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.Filled, "filled"),
-            new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.Canceled, "canceled")
+            new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.Canceled, "canceled"),
+            new KeyValuePair<HuobiOrderState, string>(HuobiOrderState.Created, "created")
         };
     }
 }

--- a/Huobi.Net/Converters/OrderTypeConverter.cs
+++ b/Huobi.Net/Converters/OrderTypeConverter.cs
@@ -18,7 +18,9 @@ namespace Huobi.Net.Converters
             new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.IOCBuy, "buy-ioc"),
             new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.IOCSell, "sell-ioc"),
             new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.LimitMakerBuy, "buy-limit-maker"),
-            new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.LimitMakerSell, "sell-limit-maker")
+            new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.LimitMakerSell, "sell-limit-maker"),
+            new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.StopLimitBuy, "buy-stop-limit"),
+            new KeyValuePair<HuobiOrderType, string>(HuobiOrderType.StopLimitSell, "sell-stop-limit")
         };
     }
 }

--- a/Huobi.Net/Objects/HuobiEnums.cs
+++ b/Huobi.Net/Objects/HuobiEnums.cs
@@ -61,7 +61,9 @@
         IOCBuy,
         IOCSell,
         LimitMakerBuy,
-        LimitMakerSell
+        LimitMakerSell,
+        StopLimitBuy,
+        StopLimitSell
     }
 
     public enum HuobiOrderState
@@ -71,7 +73,8 @@
         PartiallyFilled,
         PartiallyCanceled,
         Filled,
-        Canceled
+        Canceled,
+        Created
     }
 
     public enum HuobiAccountEventType


### PR DESCRIPTION
There are JsonSerializationException when you receive stop-limit order from API, this will fix it.
Steps to reproduce:
- Place stop-limit order via Huobi website
- Request order history via API

Please note, that this probably won't allow placing stop-limit orders via API, because they require undocumented fields, and I need just parsing them.